### PR TITLE
Add clipPath and use elements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ A list of SVG elements
 
 Just exports an array of svg element names. Those element names are:
 
-`animate circle defs ellipse g line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan`
+`animate circle clipPath defs ellipse g line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan use`
 
 ## Example
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * svgElements
  */
 
-var svgElements = 'animate circle defs ellipse g line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan'.split(' ')
+var svgElements = 'animate circle clipPath defs ellipse g line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan use'.split(' ')
 
 /**
  * Expose svgElements


### PR DESCRIPTION
[`<clipPath>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath) and [`<use>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) are SVG elements. This PR adds them to the list
